### PR TITLE
Fix mock date not having all the prototype properties. Fix mock date …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,32 +1,37 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 exports.clear = exports.advanceTo = exports.advanceBy = undefined;
 
 var _date = require('./date');
 
 Object.defineProperty(exports, 'advanceBy', {
-  enumerable: true,
-  get: function get() {
-    return _date.advanceBy;
-  }
+    enumerable: true,
+    get: function get() {
+        return _date.advanceBy;
+    }
 });
 Object.defineProperty(exports, 'advanceTo', {
-  enumerable: true,
-  get: function get() {
-    return _date.advanceTo;
-  }
+    enumerable: true,
+    get: function get() {
+        return _date.advanceTo;
+    }
 });
 Object.defineProperty(exports, 'clear', {
-  enumerable: true,
-  get: function get() {
-    return _date.clear;
-  }
+    enumerable: true,
+    get: function get() {
+        return _date.clear;
+    }
 });
 
 var _mockDate = require('./mockDate');
 
 // mock Date class
-global.window.Date = (0, _mockDate.mockDateClass)(window.Date);
+var dateClass = (0, _mockDate.mockDateClass)(Date);
+if (global.window) {
+    global.window.Date = dateClass;
+} else {
+    global.Date = dateClass;
+}

--- a/lib/mockDate.js
+++ b/lib/mockDate.js
@@ -22,12 +22,9 @@ var mockDateClass = exports.mockDateClass = function mockDateClass(D) {
       p[_key] = arguments[_key];
     }
 
-    var d = new (Function.prototype.bind.apply(D, [null].concat(_toConsumableArray(p.length === 0 ? [mockNow()] : p))))();
-
-    MD.prototype = D.prototype;
-
-    return d;
+    return new (Function.prototype.bind.apply(D, [null].concat(_toConsumableArray(p.length === 0 ? [mockNow()] : p))))();
   };
+  MD.prototype = D.prototype;
 
   // undefined means do not mock date
   MD.now = function () {

--- a/src/index.js
+++ b/src/index.js
@@ -8,4 +8,9 @@ export { advanceBy, advanceTo, clear } from './date';
 import { mockDateClass } from './mockDate';
 
 // mock Date class
-global.window.Date = mockDateClass(window.Date);
+const dateClass = mockDateClass(Date);
+if (global.window) {
+    global.window.Date = dateClass;
+} else {
+    global.Date = dateClass;
+}

--- a/src/mockDate.js
+++ b/src/mockDate.js
@@ -9,12 +9,9 @@ export const mockDateClass = D => {
   const mockNow = () => now() === undefined ? D.now() : now();
 
   const MD = function(...p) {
-    const d = new D(...(p.length === 0 ? [mockNow()] : p));
-
-    MD.prototype = D.prototype;
-
-    return d;
+    return new D(...(p.length === 0 ? [mockNow()] : p));
   };
+  MD.prototype = D.prototype;
 
   // undefined means do not mock date
   MD.now = () => mockNow();


### PR DESCRIPTION
This pull request fixes two things:
1. Date prototype did not have few methods on them when using mock date. Now it has all the prototype methods.
2. This library did not work on nodejs environment like React Native because there global.window does not exist.