### PR TITLE
Modified mock date class to extend Date

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -29,6 +29,12 @@ describe('jest-date-mock', () => {
 
     // 2018-05-27 08:00:00
     expect(new Date(Date.UTC(2018, 5, 27, 0, 0, 0)).getTime()).toBe(1530057600000);
+
+    class DerivedDate extends Date {}
+    const derivedDate = new DerivedDate();
+    expect(derivedDate).toBeInstanceOf(Date);
+    expect(derivedDate).toBeInstanceOf(DerivedDate);
+    expect(+derivedDate).toBe(0);
   });
 
   test('Date.now', () => {

--- a/lib/mockDate.js
+++ b/lib/mockDate.js
@@ -7,31 +7,24 @@ exports.mockDateClass = undefined;
 
 var _date = require('./date');
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } } /**
-                                                                                                                                                                                                     * Created by hustcc 18/05/27.
-                                                                                                                                                                                                     * Contract: i@hust.cc
-                                                                                                                                                                                                     */
-
 var mockDateClass = exports.mockDateClass = function mockDateClass(D) {
   var mockNow = function mockNow() {
     return (0, _date.now)() === undefined ? D.now() : (0, _date.now)();
   };
 
-  var MD = function MD() {
-    for (var _len = arguments.length, p = Array(_len), _key = 0; _key < _len; _key++) {
-      p[_key] = arguments[_key];
-    }
+  function MD(date) {
+    var instance = new D(date === undefined ? mockNow() : date);
+    Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+    return instance;
+  }
 
-    return new (Function.prototype.bind.apply(D, [null].concat(_toConsumableArray(p.length === 0 ? [mockNow()] : p))))();
-  };
-  MD.prototype = D.prototype;
+  MD.prototype = Object.create(D.prototype);
+  Object.setPrototypeOf(MD, D);
 
   // undefined means do not mock date
   MD.now = function () {
     return mockNow();
   };
-  MD.UTC = D.UTC;
-
   // original Date class
   MD.__OriginalDate__ = D;
   // current() is for test.
@@ -40,4 +33,7 @@ var mockDateClass = exports.mockDateClass = function mockDateClass(D) {
   };
 
   return MD;
-};
+}; /**
+    * Created by hustcc 18/05/27.
+    * Contract: i@hust.cc
+    */

--- a/src/mockDate.js
+++ b/src/mockDate.js
@@ -8,15 +8,17 @@ import { now } from './date';
 export const mockDateClass = D => {
   const mockNow = () => now() === undefined ? D.now() : now();
 
-  const MD = function(...p) {
-    return new D(...(p.length === 0 ? [mockNow()] : p));
-  };
-  MD.prototype = D.prototype;
+  function MD(date) {
+    const instance = new D(date === undefined ? mockNow() : date);
+    Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+    return instance;
+  }
+
+  MD.prototype = Object.create(D.prototype);
+  Object.setPrototypeOf(MD, D);
 
   // undefined means do not mock date
   MD.now = () => mockNow();
-  MD.UTC = D.UTC;
-
   // original Date class
   MD.__OriginalDate__ = D;
   // current() is for test.


### PR DESCRIPTION
The mock class now extends the native Date object in a way that can be further extended by any other class.

It uses the same technique used by Babel to extend native built-ins. Ideally, this library should use Babel 7 and the "env" preset configured for Node 4 (which keeps classes and so extending built-ins is easier and better performant).

Fixes #6.