### PR TITLE
Added typescript definition file.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Changes date by an offset. Can be negative.
+ *
+ * @param ms
+ * @default 0
+ */
+export declare function advanceBy(ms: number): void;
+
+/**
+ * Sets date to a timestamp.
+ *
+ * @param ms
+ * @default 0
+ */
+export declare function advanceTo(ms?: number): void;
+
+/**
+ * Un-mocks the Date class.
+ */
+export declare function clear(): void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -7,12 +7,12 @@
 export declare function advanceBy(ms: number): void;
 
 /**
- * Sets date to a timestamp.
+ * Sets date to a timestamp or Date.
  *
  * @param ms
  * @default 0
  */
-export declare function advanceTo(ms?: number): void;
+export declare function advanceTo(ms?: number | Date): void;
 
 /**
  * Un-mocks the Date class.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "Mock `window.Date` when run unit test cases with jest. Make tests of `Date` easier.",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "test": "jest",
     "build": "babel src --out-dir lib && npm run test",


### PR DESCRIPTION
#5 
Create a definition file that exports 3 functions.
The functions are typed as `void` by design - there is no usage of return values in the tests.

For maintainability it might be easy enough to just rewrite the library in TypeScript, but this file should solve most people's problems.